### PR TITLE
Template for the new rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/research-summary.md
+++ b/.github/ISSUE_TEMPLATE/research-summary.md
@@ -6,27 +6,34 @@ labels: summary,
 assignees: ''
 
 ---
+
 Description: 
+
 Estimated date of completion: 
+
 Link to Paper:
+
 Link to working draft:
+
 Source of approval: 
 
 <!--
+
 Thanks for expressing interest in proposing a summary for SCRF. Before submission, please complete the following steps: 
 
-1. Format the title of the ticket: Research Summary: Title of the Paper 
+1. Format the title of the ticket: Research Summary: Title of the Paper
 
-2. Fill out the ticket and include: 
-- A description of why this summary is novel, timely, and interesting 
-- Estimated date of completion (tentative) 
-- A link to draft Google Doc, with the following specifications: 
-   a. Copy and paste the Research Summary template in the draft 
-   b. Provide a publicly accessible link 
-   c. Request access to move the draft to SCRF's folder for Idea Stage and Drafting 
-- A source of approval: provide either a Research Pulse issue number, a link/screenshot if approved by @cipherix, or indicate if it needs approval
+2. Fill out the ticket and include:
 
-3. Assign yourself to the issue 
+  - A description of why this summary is novel, timely, and interesting 
+  - Estimated date of completion (tentative)
+  - A link to draft Google Doc, with the following specifications:
+     a. Copy and paste the Research Summary template: https://github.com/smartcontractresearchforum/docs/blob/main/en/content_research_summary_template.md in the draft 
+     b. Provide a publicly accessible link 
+     c. Request access to move the draft to SCRF's folder for Idea Stage and Drafting 
+  - A source of approval: provide either a Research Pulse issue number, a link/screenshot if approved by @cipherix, or indicate if it needs approval
+
+3. Assign yourself to the issue
 
 4. Add the label "summary", and 1-3 other relevant tags
 

--- a/.github/ISSUE_TEMPLATE/research-summary.md
+++ b/.github/ISSUE_TEMPLATE/research-summary.md
@@ -1,39 +1,33 @@
 ---
 name: Research Summary
 about: 'Use this template to create a new summary.'
-title: '[SUMMARY]'
+title: 'Research Summary: '
 labels: summary,
 assignees: ''
 
 ---
+Description: 
+Estimated date of completion: 
+Link to Paper:
+Link to working draft:
+Source of approval: 
 
-## Steps to completion
+<!--
+Thanks for expressing interest in proposing a summary for SCRF. Before submission, please complete the following steps: 
 
-- [ ] Provide context/background for broader narrative
-- [ ] GTM section filled out
-- [ ] Editing step completed
-- [ ] Proposed tags
-- [ ] Glossary items captured
-- [ ] Post GTM Meeting
+1. Format the title of the ticket: Research Summary: Title of the Paper 
 
----
+2. Fill out the ticket and include: 
+- A description of why this summary is novel, timely, and interesting 
+- Estimated date of completion (tentative) 
+- A link to draft Google Doc, with the following specifications: 
+   a. Copy and paste the Research Summary template in the draft 
+   b. Provide a publicly accessible link 
+   c. Request access to move the draft to SCRF's folder for Idea Stage and Drafting 
+- A source of approval: provide either a Research Pulse issue number, a link/screenshot if approved by @cipherix, or indicate if it needs approval
 
-## Title 
+3. Assign yourself to the issue 
 
-## Link to source
+4. Add the label "summary", and 1-3 other relevant tags
 
-## Link to draft
-
-## Assignee
-
-## Content type tag (summary, discussion)
-
-## Category Tag (our list of categories)
-
-## Subcategory tag (3 freeform tags or text)
-
-## Size of task tag (small, medium, large)
-
-## Description of why this is good for SCRF
-
-## Links to required reading (0 to 3 items)
+--->


### PR DESCRIPTION
The previous template is outdated for several reasons:
1.  Steps to completion are now posted separately by the PM
2.  The title, assignee, content tag, category tag, subcategory tag should be provided at their according fields, not in the description
3.  Size of the tag is replaced with an estimated time to completion
4.  Description of "why this is good for SCRF" is now required to be "An explanation of why this summary is novel, timely, and interesting"

Therefore I'm proposing this new issue template to reflect the need for change to the reasons above, and in addition:
5. To remind the users to add their draft to the shared Google folder
6. To remind the users to follow the summary template for their draft
7.  To provide guidance and a reminder to what kind of approval they need from LCR to do a research summary

The template has been reviewed and passed by the moderation team (Rachel) to check for style and grammar.